### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Python CI
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AyushHL/CryptoLib/security/code-scanning/1](https://github.com/AyushHL/CryptoLib/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since this is a basic CI pipeline that installs dependencies and runs tests, it only requires read access to the repository contents. We will set `contents: read` as the minimal required permission. This change will ensure that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
